### PR TITLE
Implement layer map from preload

### DIFF
--- a/apps/web/preload/script/api/index.ts
+++ b/apps/web/preload/script/api/index.ts
@@ -1,4 +1,4 @@
-import { processDom } from './dom';
+import { processDom, type ProcessDomResult } from './dom';
 import {
     getChildrenCount,
     getElementAtLoc,
@@ -84,3 +84,4 @@ export const preloadMethods = {
 }
 
 export type PenpalChildMethods = typeof preloadMethods;
+export type { ProcessDomResult };

--- a/apps/web/preload/script/api/ready.ts
+++ b/apps/web/preload/script/api/ready.ts
@@ -18,7 +18,7 @@ function keepDomUpdated() {
 
     const interval = setInterval(() => {
         try {
-            if (processDom()) {
+            if (processDom() !== null) {
                 clearInterval(interval);
                 domUpdateInterval = null;
             }


### PR DESCRIPTION
## Summary
- return layer map data from web preload processDom
- export types from preload API
- use layer data on the client when connecting frames
- adjust DOM ready handler to match new return type

## Testing
- `bun run lint` *(fails: `next` not found)*
- `bun test` *(fails: cannot resolve packages)*

------
https://chatgpt.com/codex/tasks/task_e_685b5ec320bc832594326fd12b752b34